### PR TITLE
Add option to change screen resolution using an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV TZ=Europe/Zurich
+ENV SCREEN_RESOLUTION 1024x768
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Add the octave repo

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The Octave GUI have to be accessed through a browser in a noVNC windows.
 * `firefox http://localhost:8083`
 * octave is launched, just run some script e.g. my_sombrero.m
 
+Adding the parameter `-e SCREEN_RESOLUTION=<width>x<height>` the screen size displayed is adjusted to the one in the environment variable. By default it is 1024x768.
+
 ### Manual Build
 
 * `docker build -t epflsti/octave-x11-novnc-docker:latest .`

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1024x768x24
+command=/usr/bin/Xvfb :0 -screen 0 %(ENV_SCREEN_RESOLUTION)sx24
 autorestart=true
 
 [program:x11vnc]


### PR DESCRIPTION
Changed the hard-coded resolution for an interpolated variable. Supervisord configuration file allows for Python style string interpolation in this case.

The default resolution is defined in the Dockerfile and can be overriden by setting the environment variable SCREEN_RESOLUTION as noted in the Readme.

Feel free to fiddle around and change any name.